### PR TITLE
Update IBiomeSpecificProcessingRecipe.java

### DIFF
--- a/src/main/java/com/petrolpark/recipe/advancedprocessing/IBiomeSpecificProcessingRecipe.java
+++ b/src/main/java/com/petrolpark/recipe/advancedprocessing/IBiomeSpecificProcessingRecipe.java
@@ -88,7 +88,7 @@ public interface IBiomeSpecificProcessingRecipe {
 
         @Override
         public String serialize() {
-            return "#"+tag.toString();
+            return "#"+tag.location();
         };
     };
 };


### PR DESCRIPTION
Fixes invalid biome tag serialization.

toString() method returns `TagKey[minecraft:biome.... something`.
location() gives `minecraft:is_badlands` etc.

This works with https://github.com/petrolpark/Destroy/pull/454
Probably fix https://github.com/petrolpark/Destroy/issues/452