### PR TITLE
Fix crash

### DIFF
--- a/src/main/java/com/petrolpark/badge/BadgeHandler.java
+++ b/src/main/java/com/petrolpark/badge/BadgeHandler.java
@@ -73,7 +73,7 @@ public class BadgeHandler {
                         pair.getFirst().grantAdvancement(player));
                 });
             } catch (Exception e) {};
-        }).join();
+        });
 
     };
 
@@ -94,7 +94,7 @@ public class BadgeHandler {
 
                 responseFuture.thenAcceptAsync(response -> {
                     getAndAddBadges(player);
-                }).join();
+                });
             
             } else { // If Early Bird is no longer obtainable, get the Badges straight away
                 getAndAddBadges(player);


### PR DESCRIPTION
That pull request fixes crash, that provided in crash-report.
Crash was caused by waiting of response from server.

But we use async with completeble future, why do we wait for response? That because someone put `.join()` just because IDE said that or idk, from some 10-year-old guide.
For realization, `.join()` is like `thread.join()` in C++, it waits for ending of task. That what caused crash.

Crash-report:
[crash-2024-12-06_02.42.48-server.txt](https://github.com/user-attachments/files/18031154/crash-2024-12-06_02.42.48-server.txt)
