### PR TITLE
Fix PetrolparkMixinPlugin.requireMultipleMods not actually preventing mixins from being loaded

### DIFF
--- a/src/main/java/com/petrolpark/mixin/plugin/PetrolparkMixinPlugin.java
+++ b/src/main/java/com/petrolpark/mixin/plugin/PetrolparkMixinPlugin.java
@@ -40,7 +40,7 @@ public class PetrolparkMixinPlugin implements IMixinConfigPlugin {
      * @param requiredMods Mods upon which this Mixin depends
      */
     protected void requireMultipleMods(String mixinClassName, CompatMods ...requiredMods) {
-        String className = getMixinPackage()+".compat."+requiredMods[0]+"."+mixinClassName;
+        String className = getMixinPackage()+".compat."+requiredMods[0].id+"."+mixinClassName;
         shouldLoad.put(className, () -> {
             for (CompatMods mod : requiredMods) if (!mod.isLoading()) return false;
             return true;


### PR DESCRIPTION
Turns out it's using the provided enum's all-uppercase name to build the full name of the mixin class, which causes it to get it wrong every time.