### PR TITLE
✨Shader effects✨ (petrolpark edition)

### DIFF
--- a/src/main/java/com/petrolpark/PetrolparkPostUniforms.java
+++ b/src/main/java/com/petrolpark/PetrolparkPostUniforms.java
@@ -1,0 +1,34 @@
+package com.petrolpark;
+
+import com.mojang.blaze3d.shaders.AbstractUniform;
+
+import java.util.function.Consumer;
+
+public enum PetrolparkPostUniforms {
+    EFFECT_FACTOR("EffectFactor");
+
+    final String name;
+    Consumer<AbstractUniform> onUpdate;
+
+    PetrolparkPostUniforms(String name, Consumer<AbstractUniform> onUpdate) {
+        this.name = name;
+        this.onUpdate = onUpdate;
+    }
+
+    PetrolparkPostUniforms(String name) {
+        this.name = name;
+        this.onUpdate = (uniform) -> {};
+    }
+
+    public void update(Consumer<AbstractUniform> onUpdate) {
+        this.onUpdate = onUpdate;
+    }
+
+    public void applyUniform(AbstractUniform uniform) {
+        this.onUpdate.accept(uniform);
+    }
+
+    public String getName() {
+        return this.name;
+    }
+}

--- a/src/main/java/com/petrolpark/event/CommonEvents.java
+++ b/src/main/java/com/petrolpark/event/CommonEvents.java
@@ -1,7 +1,5 @@
 package com.petrolpark.event;
 
-import java.util.stream.Stream;
-
 import com.petrolpark.Petrolpark;
 import com.petrolpark.PetrolparkConfig;
 import com.petrolpark.PetrolparkTags;
@@ -9,16 +7,18 @@ import com.petrolpark.badge.BadgesCapability;
 import com.petrolpark.command.ContaminateCommand;
 import com.petrolpark.contamination.Contaminant;
 import com.petrolpark.contamination.ItemContamination;
-import com.petrolpark.item.decay.IDecayingItem;
 import com.petrolpark.item.decay.DecayingItemHandler.ServerDecayingItemHandler;
+import com.petrolpark.item.decay.IDecayingItem;
 import com.petrolpark.shop.customer.EntityCustomer;
 import com.petrolpark.team.SinglePlayerTeam;
-
+import com.petrolpark.util.IGameRendererMixin;
+import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.alchemy.PotionUtils;
 import net.minecraft.world.item.alchemy.Potions;
+import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.RegisterCommandsEvent;
@@ -27,6 +27,8 @@ import net.minecraftforge.event.brewing.PotionBrewEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+
+import java.util.stream.Stream;
 
 @EventBusSubscriber
 public class CommonEvents {
@@ -94,5 +96,11 @@ public class CommonEvents {
             if (PetrolparkConfig.SERVER.brewingPropagatesContaminants.get()) ItemContamination.perpetuateSingle(Stream.of(event.getItem(3), potion).dropWhile(s -> PetrolparkConfig.SERVER.brewingWaterBottleContaminantsIgnored.get() && PotionUtils.getPotion(s) == Potions.WATER), potion);
         };
     };
-    
+
+    //DISCONNECTION CLEANING CLIENT SIDE
+    @SubscribeEvent
+    public static void onPlayerLogOut(ClientPlayerNetworkEvent.LoggingOut event) {
+        IGameRendererMixin gameRenderer = (( IGameRendererMixin ) Minecraft.getInstance().gameRenderer);
+        gameRenderer.cleanShaderEffects();
+    }
 };

--- a/src/main/java/com/petrolpark/event/ModEvents.java
+++ b/src/main/java/com/petrolpark/event/ModEvents.java
@@ -45,8 +45,8 @@ public class ModEvents {
                     for ( MobEffect effect : ForgeRegistries.MOB_EFFECTS.getValues() ) {
                         if (effect instanceof IShaderEffect shaderEffect ) {
                             ResourceLocation location = shaderEffect.getShader();
-                            if (location != null && !ShaderEffectReloadHandler.hasShader(location)) {
-                                ShaderEffectReloadHandler.createShader(location, shaderEffect, mc, pResourceManager);
+                            if (location != null && !ShaderEffectReloadHandler.hasShader(shaderEffect)) {
+                                ShaderEffectReloadHandler.createShader(shaderEffect, mc, pResourceManager);
                             }
                         }
                     }

--- a/src/main/java/com/petrolpark/event/ModEvents.java
+++ b/src/main/java/com/petrolpark/event/ModEvents.java
@@ -3,12 +3,24 @@ package com.petrolpark.event;
 import com.petrolpark.Petrolpark;
 import com.petrolpark.PetrolparkRegistries;
 import com.petrolpark.contamination.Contaminant;
+import com.petrolpark.shadereffects.IShaderEffect;
+import com.petrolpark.shadereffects.ShaderEffectReloadHandler;
 import com.petrolpark.shop.Shop;
 import com.petrolpark.shop.offer.ShopOfferGenerator;
-
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.util.profiling.ProfilerFiller;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraftforge.client.event.RegisterClientReloadListenersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.registries.DataPackRegistryEvent;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 @EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, modid = Petrolpark.MOD_ID)
 public class ModEvents {
@@ -19,4 +31,29 @@ public class ModEvents {
         event.dataPackRegistry(PetrolparkRegistries.Keys.SHOP, Shop.CODEC, Shop.CODEC);
         event.dataPackRegistry(PetrolparkRegistries.Keys.SHOP_OFFER_GENERATOR, ShopOfferGenerator.CODEC, ShopOfferGenerator.CODEC);
     };
+
+    @SubscribeEvent
+    public static void registerClientReloadListeners(RegisterClientReloadListenersEvent event) {
+        event.registerReloadListener(new PreparableReloadListener() {
+            @Override
+            public CompletableFuture<Void> reload(PreparationBarrier pPreparationBarrier, ResourceManager pResourceManager, ProfilerFiller pPreparationsProfiler, ProfilerFiller pReloadProfiler, Executor pBackgroundExecutor, Executor pGameExecutor) {
+                return CompletableFuture.runAsync(() -> {
+                    ShaderEffectReloadHandler.clearCache();
+
+                    Minecraft mc = Minecraft.getInstance();
+
+                    for ( MobEffect effect : ForgeRegistries.MOB_EFFECTS.getValues() ) {
+                        if (effect instanceof IShaderEffect shaderEffect ) {
+                            ResourceLocation location = shaderEffect.getShader();
+                            if (location != null && !ShaderEffectReloadHandler.hasShader(location)) {
+                                ShaderEffectReloadHandler.createShader(location, shaderEffect, mc, pResourceManager);
+                            }
+                        }
+                    }
+
+                    System.out.println("[Petrolpark] All shader effects preloaded.");
+                }, pGameExecutor).thenCompose(pPreparationBarrier::wait);
+            }
+        });
+    }
 };

--- a/src/main/java/com/petrolpark/mixin/MobEffectInstanceMixin.java
+++ b/src/main/java/com/petrolpark/mixin/MobEffectInstanceMixin.java
@@ -12,6 +12,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.common.extensions.IForgeMobEffectInstance;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -23,7 +24,7 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import java.util.Optional;
 
 @Mixin( MobEffectInstance.class)
-public abstract class MobEffectInstanceMixin implements IMobEffectInstanceMixin, Comparable<MobEffectInstance>, net.minecraftforge.common.extensions.IForgeMobEffectInstance{
+public abstract class MobEffectInstanceMixin implements IMobEffectInstanceMixin, Comparable<MobEffectInstance>, IForgeMobEffectInstance{
     @Shadow
     int duration;
 
@@ -38,7 +39,6 @@ public abstract class MobEffectInstanceMixin implements IMobEffectInstanceMixin,
         throw new AbstractMethodError("Shadow");
     };
 
-    private boolean shouldUpdateUniform = false;
     private boolean shaderInitialized = false;
 
     @Inject(method = "<init>(Lnet/minecraft/world/effect/MobEffect;IIZZZLnet/minecraft/world/effect/MobEffectInstance;Ljava/util/Optional;)V", at = @At("RETURN"))
@@ -48,18 +48,17 @@ public abstract class MobEffectInstanceMixin implements IMobEffectInstanceMixin,
 
     @Inject(method = "tick", at = @At("HEAD"))
     private void inTick(LivingEntity pEntity, Runnable pOnExpirationRunnable, CallbackInfoReturnable<Boolean> ci) {
-        if (!pEntity.level().isClientSide() && !sentInitialDuration && pEntity instanceof ServerPlayer ) {
-            PetrolparkMessages.sendToClient(new SyncInitialDurationPacket(this.initialDuration, this.effect), (( ServerPlayer ) pEntity));
+        //Server side
+        if (!pEntity.level().isClientSide() && !sentInitialDuration && pEntity instanceof ServerPlayer player && effect instanceof IShaderEffect) {
+            PetrolparkMessages.sendToClient(new SyncInitialDurationPacket(this.initialDuration, this.effect), player);
+            sentInitialDuration = true;
         }
-        if (pEntity.level().isClientSide()) {
+
+        //Client side
+        if (pEntity.level().isClientSide() && effect instanceof IShaderEffect shaderEffect && !shaderInitialized) {
+            shaderInitialized = true;
             IGameRendererMixin gameRenderer = ( IGameRendererMixin ) Minecraft.getInstance().gameRenderer;
-            if (effect instanceof IShaderEffect ) {
-                if (!shaderInitialized) {
-                    shaderInitialized = true;
-                    shouldUpdateUniform = true;
-                    gameRenderer.addMobEffectInstanceShader((( IShaderEffect ) effect).getShader(), ((MobEffectInstance) (Object) this));
-                }
-            }
+            gameRenderer.addMobEffectInstanceShader(shaderEffect.getShader(), ((MobEffectInstance) (Object) this));
         }
     }
 
@@ -71,31 +70,28 @@ public abstract class MobEffectInstanceMixin implements IMobEffectInstanceMixin,
     }
 
     @Inject(method = "loadSpecifiedEffect", at = @At("RETURN"), cancellable = true, locals = LocalCapture.CAPTURE_FAILSOFT)
-    private static void inLoadSpecifiedEffect(MobEffect pEffect, CompoundTag pNbt, CallbackInfoReturnable<MobEffectInstance> ci, int i, int j, boolean flag, boolean flag1, boolean flag2, MobEffectInstance mobeffectinstance, Optional<MobEffectInstance.FactorData> optional) {
+    private static void inLoadSpecifiedEffect(MobEffect pEffect, CompoundTag pNbt, CallbackInfoReturnable<MobEffectInstance> ci, int i, int j, boolean flag, boolean flag1, boolean flag2, MobEffectInstance mobeffectinstance, Optional< MobEffectInstance.FactorData> optional) {
         int initialDuration = pNbt.getInt("InitialDuration");
-        MobEffectInstance inMobEffectinstance = readCurativeItems(new MobEffectInstance(pEffect, j, Math.max(0, i), flag, flag1, flag2, mobeffectinstance, optional), pNbt);
-        if (inMobEffectinstance.getEffect() instanceof  IShaderEffect) {
-            if (initialDuration > 0) {
-                (( IMobEffectInstanceMixin ) inMobEffectinstance).setInitialDuration(initialDuration);
-            } else {
-                (( IMobEffectInstanceMixin ) inMobEffectinstance).setInitialDuration(1);
-            }
+
+        MobEffectInstance instance = readCurativeItems(
+                new MobEffectInstance(pEffect, j, Math.max(0, i), flag, flag1, flag2, mobeffectinstance, optional),
+                pNbt
+        );
+
+        if (instance.getEffect() instanceof  IShaderEffect) {
+            (( IMobEffectInstanceMixin ) instance).setInitialDuration(Math.max(1, initialDuration));
         }
-        ci.setReturnValue(inMobEffectinstance);
+        ci.setReturnValue(instance);
         ci.cancel();
     }
 
     @Override
     public void updateUniforms() {
-        if (duration >= 0) {
-            PetrolparkPostUniforms.EFFECT_FACTOR.update((uniform) -> {
-                uniform.set((float) duration /  initialDuration);
-            });
-        } else {
-            PetrolparkPostUniforms.EFFECT_FACTOR.update((uniform) -> {
-                uniform.set(0.5f);
-            });
-        }
+        float value = duration >= 0 && initialDuration > 0 ?
+                (float) duration / initialDuration :
+                0.5f;
+
+        PetrolparkPostUniforms.EFFECT_FACTOR.update(uniform -> uniform.set(value));
     }
 
     @Override

--- a/src/main/java/com/petrolpark/mixin/MobEffectInstanceMixin.java
+++ b/src/main/java/com/petrolpark/mixin/MobEffectInstanceMixin.java
@@ -1,0 +1,106 @@
+package com.petrolpark.mixin;
+
+import com.petrolpark.PetrolparkPostUniforms;
+import com.petrolpark.network.PetrolparkMessages;
+import com.petrolpark.shadereffects.IShaderEffect;
+import com.petrolpark.shadereffects.packet.SyncInitialDurationPacket;
+import com.petrolpark.util.IGameRendererMixin;
+import com.petrolpark.util.IMobEffectInstanceMixin;
+import net.minecraft.client.Minecraft;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.util.Optional;
+
+@Mixin( MobEffectInstance.class)
+public abstract class MobEffectInstanceMixin implements IMobEffectInstanceMixin, Comparable<MobEffectInstance>, net.minecraftforge.common.extensions.IForgeMobEffectInstance{
+    @Shadow
+    int duration;
+
+    @Shadow
+    private MobEffect effect;
+
+    public int initialDuration;
+    private boolean sentInitialDuration = false;
+
+    @Shadow
+    protected static MobEffectInstance readCurativeItems(MobEffectInstance effect, CompoundTag nbt) {
+        throw new AbstractMethodError("Shadow");
+    };
+
+    private boolean shouldUpdateUniform = false;
+    private boolean shaderInitialized = false;
+
+    @Inject(method = "<init>(Lnet/minecraft/world/effect/MobEffect;IIZZZLnet/minecraft/world/effect/MobEffectInstance;Ljava/util/Optional;)V", at = @At("RETURN"))
+    private void onInitialize(CallbackInfo ci) {
+        initialDuration = duration;
+    }
+
+    @Inject(method = "tick", at = @At("HEAD"))
+    private void inTick(LivingEntity pEntity, Runnable pOnExpirationRunnable, CallbackInfoReturnable<Boolean> ci) {
+        if (!pEntity.level().isClientSide() && !sentInitialDuration && pEntity instanceof ServerPlayer ) {
+            PetrolparkMessages.sendToClient(new SyncInitialDurationPacket(this.initialDuration, this.effect), (( ServerPlayer ) pEntity));
+        }
+        if (pEntity.level().isClientSide()) {
+            IGameRendererMixin gameRenderer = ( IGameRendererMixin ) Minecraft.getInstance().gameRenderer;
+            if (effect instanceof IShaderEffect ) {
+                if (!shaderInitialized) {
+                    shaderInitialized = true;
+                    shouldUpdateUniform = true;
+                    gameRenderer.addMobEffectInstanceShader((( IShaderEffect ) effect).getShader(), ((MobEffectInstance) (Object) this));
+                }
+            }
+        }
+    }
+
+    @Inject(method = "writeDetailsTo", at = @At("TAIL"))
+    public void inWriteDetailsTo(CompoundTag pNbt, CallbackInfo ci) {
+        if (this.effect instanceof IShaderEffect) {
+            pNbt.putInt("InitialDuration", initialDuration);
+        }
+    }
+
+    @Inject(method = "loadSpecifiedEffect", at = @At("RETURN"), cancellable = true, locals = LocalCapture.CAPTURE_FAILSOFT)
+    private static void inLoadSpecifiedEffect(MobEffect pEffect, CompoundTag pNbt, CallbackInfoReturnable<MobEffectInstance> ci, int i, int j, boolean flag, boolean flag1, boolean flag2, MobEffectInstance mobeffectinstance, Optional<MobEffectInstance.FactorData> optional) {
+        int initialDuration = pNbt.getInt("InitialDuration");
+        MobEffectInstance inMobEffectinstance = readCurativeItems(new MobEffectInstance(pEffect, j, Math.max(0, i), flag, flag1, flag2, mobeffectinstance, optional), pNbt);
+        if (inMobEffectinstance.getEffect() instanceof  IShaderEffect) {
+            if (initialDuration > 0) {
+                (( IMobEffectInstanceMixin ) inMobEffectinstance).setInitialDuration(initialDuration);
+            } else {
+                (( IMobEffectInstanceMixin ) inMobEffectinstance).setInitialDuration(1);
+            }
+        }
+        ci.setReturnValue(inMobEffectinstance);
+        ci.cancel();
+    }
+
+    @Override
+    public void updateUniforms() {
+        if (duration >= 0) {
+            PetrolparkPostUniforms.EFFECT_FACTOR.update((uniform) -> {
+                uniform.set((float) duration /  initialDuration);
+            });
+        } else {
+            PetrolparkPostUniforms.EFFECT_FACTOR.update((uniform) -> {
+                uniform.set(0.5f);
+            });
+        }
+    }
+
+    @Override
+    public void setInitialDuration(int initialDuration) {
+        this.initialDuration = initialDuration;
+    }
+
+}

--- a/src/main/java/com/petrolpark/mixin/MobEffectInstanceMixin.java
+++ b/src/main/java/com/petrolpark/mixin/MobEffectInstanceMixin.java
@@ -55,7 +55,7 @@ public abstract class MobEffectInstanceMixin implements IMobEffectInstanceMixin,
         }
 
         //Client side
-        if (pEntity.level().isClientSide() && effect instanceof IShaderEffect shaderEffect && !shaderInitialized) {
+        if (pEntity.level().isClientSide() && !shaderInitialized && effect instanceof IShaderEffect shaderEffect) {
             shaderInitialized = true;
             IGameRendererMixin gameRenderer = ( IGameRendererMixin ) Minecraft.getInstance().gameRenderer;
             gameRenderer.addMobEffectInstanceShader(shaderEffect.getShader(), ((MobEffectInstance) (Object) this));

--- a/src/main/java/com/petrolpark/mixin/MobEffectMixin.java
+++ b/src/main/java/com/petrolpark/mixin/MobEffectMixin.java
@@ -10,12 +10,14 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin( MobEffect.class )
-public abstract class MobEffectMixin implements IShaderEffect{
+public abstract class MobEffectMixin {
     @Inject(
             method = "removeAttributeModifiers",
             at = @At("HEAD")
     )
     public void inRemoveAttributeModifiers(LivingEntity pLivingEntity, AttributeMap pAttributeMap, int pAmplifier, CallbackInfo ci) {
-        IShaderEffect.super.cleanupShader(pLivingEntity, (( MobEffect ) (Object) this));
+        if ((Object) this instanceof IShaderEffect shaderEffect) {
+            shaderEffect.cleanupShader(pLivingEntity, (MobEffect) (Object) this);
+        }
     }
 }

--- a/src/main/java/com/petrolpark/mixin/MobEffectMixin.java
+++ b/src/main/java/com/petrolpark/mixin/MobEffectMixin.java
@@ -1,0 +1,21 @@
+package com.petrolpark.mixin;
+
+import com.petrolpark.shadereffects.IShaderEffect;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.AttributeMap;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin( MobEffect.class )
+public abstract class MobEffectMixin implements IShaderEffect{
+    @Inject(
+            method = "removeAttributeModifiers",
+            at = @At("HEAD")
+    )
+    public void inRemoveAttributeModifiers(LivingEntity pLivingEntity, AttributeMap pAttributeMap, int pAmplifier, CallbackInfo ci) {
+        IShaderEffect.super.cleanupShader(pLivingEntity, (( MobEffect ) (Object) this));
+    }
+}

--- a/src/main/java/com/petrolpark/mixin/client/GameRendererMixin.java
+++ b/src/main/java/com/petrolpark/mixin/client/GameRendererMixin.java
@@ -1,6 +1,7 @@
 package com.petrolpark.mixin.client;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.petrolpark.shadereffects.ShaderEffectReloadHandler;
 import com.petrolpark.util.IGameRendererMixin;
 import com.petrolpark.util.IMobEffectInstanceMixin;
 import net.minecraft.client.Minecraft;
@@ -17,7 +18,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -59,22 +59,21 @@ public class GameRendererMixin implements IGameRendererMixin {
 
     @Override
     public void addMobEffectInstanceShader(ResourceLocation location, MobEffectInstance effect) {
-        try {
-            PostChain postChain = new PostChain(this.minecraft.getTextureManager(), this.resourceManager, this.minecraft.getMainRenderTarget(), location);
-            postChain.resize(this.minecraft.getWindow().getWidth(), this.minecraft.getWindow().getHeight());
-            loadedEffects.put((( IMobEffectInstanceMixin ) effect), postChain);
-        } catch ( IOException e ) {
-            System.err.println("[Petrolpark] Failed to load shader: " + location);
-            e.printStackTrace();
+        if (ShaderEffectReloadHandler.hasForbiddenEffect(effect.getEffect())) return;
+
+        PostChain postChain = ShaderEffectReloadHandler.getShader(location);
+
+        if (postChain == null) {
+            System.err.println("[Petrolpark] Shader wasn't preloaded as intended: " + location);
+            return;
         }
+
+        loadedEffects.put((( IMobEffectInstanceMixin ) effect), postChain);
     }
 
     @Override
     public void removeMobEffectInstanceShader(IMobEffectInstanceMixin effect) {
-        PostChain postChain = loadedEffects.remove(effect);
-        if (postChain != null) {
-            postChain.close();
-        }
+         loadedEffects.remove(effect);
     }
 
     @Override

--- a/src/main/java/com/petrolpark/mixin/client/GameRendererMixin.java
+++ b/src/main/java/com/petrolpark/mixin/client/GameRendererMixin.java
@@ -1,6 +1,7 @@
 package com.petrolpark.mixin.client;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.petrolpark.shadereffects.IShaderEffect;
 import com.petrolpark.shadereffects.ShaderEffectReloadHandler;
 import com.petrolpark.util.IGameRendererMixin;
 import com.petrolpark.util.IMobEffectInstanceMixin;
@@ -59,9 +60,7 @@ public class GameRendererMixin implements IGameRendererMixin {
 
     @Override
     public void addMobEffectInstanceShader(ResourceLocation location, MobEffectInstance effect) {
-        if (ShaderEffectReloadHandler.hasForbiddenEffect(effect.getEffect())) return;
-
-        PostChain postChain = ShaderEffectReloadHandler.getShader(location);
+        PostChain postChain = ShaderEffectReloadHandler.getShader((( IShaderEffect ) effect.getEffect()));
 
         if (postChain == null) {
             System.err.println("[Petrolpark] Shader wasn't preloaded as intended: " + location);

--- a/src/main/java/com/petrolpark/mixin/client/GameRendererMixin.java
+++ b/src/main/java/com/petrolpark/mixin/client/GameRendererMixin.java
@@ -1,0 +1,79 @@
+package com.petrolpark.mixin.client;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.petrolpark.util.IGameRendererMixin;
+import com.petrolpark.util.IMobEffectInstanceMixin;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.PostChain;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.world.effect.MobEffectInstance;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.io.IOException;
+import java.util.IdentityHashMap;
+
+@Mixin( GameRenderer.class )
+public class GameRendererMixin implements IGameRendererMixin {
+    @Shadow
+    @Final
+    Minecraft minecraft;
+
+    @Shadow
+    @Final
+    ResourceManager resourceManager;
+
+    @Unique
+    IdentityHashMap<IMobEffectInstanceMixin, PostChain> loadedEffects = new IdentityHashMap<>();
+
+    @Inject(
+            method = "render",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcom/mojang/blaze3d/pipeline/RenderTarget;bindWrite(Z)V"
+            )
+    )
+    public void inRender(float pPartialTicks, long pNanoTime, boolean pRenderLevel, CallbackInfo ci) {
+        for ( IMobEffectInstanceMixin effect : loadedEffects.keySet()) {
+            PostChain postChain = loadedEffects.get(effect);
+            effect.updateUniforms();
+
+            RenderSystem.disableBlend();
+            RenderSystem.disableDepthTest();
+            RenderSystem.resetTextureMatrix();
+            postChain.process(pPartialTicks);
+        }
+    }
+
+    @Override
+    public void addMobEffectInstanceShader(ResourceLocation location, MobEffectInstance effect) {
+        try {
+            PostChain postChain = new PostChain(this.minecraft.getTextureManager(), this.resourceManager, this.minecraft.getMainRenderTarget(), location);
+            postChain.resize(this.minecraft.getWindow().getWidth(), this.minecraft.getWindow().getHeight());
+            loadedEffects.put((( IMobEffectInstanceMixin ) effect), postChain);
+        } catch ( IOException e ) {
+            System.out.println("Shader ["+ location +"] failed to load O-O");
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void removeMobEffectInstanceShader(IMobEffectInstanceMixin effect) {
+        PostChain postChain = loadedEffects.remove(effect);
+        postChain.close();
+    }
+
+    @Override
+    public void cleanShaderEffects() {
+        for (IMobEffectInstanceMixin mei : loadedEffects.keySet()) {
+            removeMobEffectInstanceShader(mei);
+        }
+    }
+}

--- a/src/main/java/com/petrolpark/mixin/client/GameRendererMixin.java
+++ b/src/main/java/com/petrolpark/mixin/client/GameRendererMixin.java
@@ -18,7 +18,9 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.IdentityHashMap;
+import java.util.Map;
 
 @Mixin( GameRenderer.class )
 public class GameRendererMixin implements IGameRendererMixin {
@@ -41,13 +43,16 @@ public class GameRendererMixin implements IGameRendererMixin {
             )
     )
     public void inRender(float pPartialTicks, long pNanoTime, boolean pRenderLevel, CallbackInfo ci) {
-        for ( IMobEffectInstanceMixin effect : loadedEffects.keySet()) {
-            PostChain postChain = loadedEffects.get(effect);
+        for ( Map.Entry<IMobEffectInstanceMixin, PostChain> entry : loadedEffects.entrySet()) {
+            IMobEffectInstanceMixin effect = entry.getKey();
+            PostChain postChain = entry.getValue();
+
             effect.updateUniforms();
 
             RenderSystem.disableBlend();
             RenderSystem.disableDepthTest();
             RenderSystem.resetTextureMatrix();
+
             postChain.process(pPartialTicks);
         }
     }
@@ -59,7 +64,7 @@ public class GameRendererMixin implements IGameRendererMixin {
             postChain.resize(this.minecraft.getWindow().getWidth(), this.minecraft.getWindow().getHeight());
             loadedEffects.put((( IMobEffectInstanceMixin ) effect), postChain);
         } catch ( IOException e ) {
-            System.out.println("Shader ["+ location +"] failed to load O-O");
+            System.err.println("[Petrolpark] Failed to load shader: " + location);
             e.printStackTrace();
         }
     }
@@ -67,13 +72,15 @@ public class GameRendererMixin implements IGameRendererMixin {
     @Override
     public void removeMobEffectInstanceShader(IMobEffectInstanceMixin effect) {
         PostChain postChain = loadedEffects.remove(effect);
-        postChain.close();
+        if (postChain != null) {
+            postChain.close();
+        }
     }
 
     @Override
     public void cleanShaderEffects() {
-        for (IMobEffectInstanceMixin mei : loadedEffects.keySet()) {
-            removeMobEffectInstanceShader(mei);
+        for (IMobEffectInstanceMixin effect : new ArrayList<>(loadedEffects.keySet()) ) {
+            removeMobEffectInstanceShader(effect);
         }
     }
 }

--- a/src/main/java/com/petrolpark/mixin/client/PostPassMixin.java
+++ b/src/main/java/com/petrolpark/mixin/client/PostPassMixin.java
@@ -18,8 +18,11 @@ public abstract class PostPassMixin {
 
     @Inject(method = "process", at = @At(value = "HEAD"))
     public void inProcess(float pPartialTicks, CallbackInfo ci) {
-        for ( PetrolparkPostUniforms postUniform : PetrolparkPostUniforms.values() ) {
-            postUniform.applyUniform(this.effect.safeGetUniform(postUniform.getName()));
+        if (effect == null) return;
+
+        for (PetrolparkPostUniforms uniform : PetrolparkPostUniforms.values()) {
+            var shaderUniform = effect.safeGetUniform(uniform.getName());
+            uniform.applyUniform(shaderUniform);
         }
     }
 }

--- a/src/main/java/com/petrolpark/mixin/client/PostPassMixin.java
+++ b/src/main/java/com/petrolpark/mixin/client/PostPassMixin.java
@@ -1,0 +1,25 @@
+package com.petrolpark.mixin.client;
+
+import com.petrolpark.PetrolparkPostUniforms;
+import net.minecraft.client.renderer.EffectInstance;
+import net.minecraft.client.renderer.PostPass;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin( PostPass.class)
+public abstract class PostPassMixin {
+    @Shadow
+    @Final
+    private EffectInstance effect;
+
+    @Inject(method = "process", at = @At(value = "HEAD"))
+    public void inProcess(float pPartialTicks, CallbackInfo ci) {
+        for ( PetrolparkPostUniforms postUniform : PetrolparkPostUniforms.values() ) {
+            postUniform.applyUniform(this.effect.safeGetUniform(postUniform.getName()));
+        }
+    }
+}

--- a/src/main/java/com/petrolpark/mobeffects/SimpleMobEffect.java
+++ b/src/main/java/com/petrolpark/mobeffects/SimpleMobEffect.java
@@ -1,12 +1,19 @@
 package com.petrolpark.mobeffects;
 
+import com.petrolpark.Petrolpark;
+import com.petrolpark.shadereffects.IShaderEffect;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 
-public class SimpleMobEffect extends MobEffect {
+public class SimpleMobEffect extends MobEffect implements IShaderEffect {
 
     protected SimpleMobEffect(MobEffectCategory category, int color) {
         super(category, color);
     };
-    
+
+    @Override
+    public ResourceLocation getShader() {
+        return Petrolpark.asResource("shaders/post/lead_poisoning.json");
+    }
 };

--- a/src/main/java/com/petrolpark/mobeffects/SimpleMobEffect.java
+++ b/src/main/java/com/petrolpark/mobeffects/SimpleMobEffect.java
@@ -1,19 +1,11 @@
 package com.petrolpark.mobeffects;
 
-import com.petrolpark.Petrolpark;
-import com.petrolpark.shadereffects.IShaderEffect;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 
-public class SimpleMobEffect extends MobEffect implements IShaderEffect {
+public class SimpleMobEffect extends MobEffect {
 
     protected SimpleMobEffect(MobEffectCategory category, int color) {
         super(category, color);
-    };
-
-    @Override
-    public ResourceLocation getShader() {
-        return Petrolpark.asResource("shaders/post/lead_poisoning.json");
     }
-};
+}

--- a/src/main/java/com/petrolpark/network/PetrolparkMessages.java
+++ b/src/main/java/com/petrolpark/network/PetrolparkMessages.java
@@ -5,6 +5,8 @@ import java.util.function.Function;
 import com.petrolpark.Petrolpark;
 import com.petrolpark.network.packet.C2SPacket;
 import com.petrolpark.network.packet.S2CPacket;
+import com.petrolpark.shadereffects.packet.MEIShaderRemovePacket;
+import com.petrolpark.shadereffects.packet.SyncInitialDurationPacket;
 import com.petrolpark.team.packet.BindTeamBlockPacket;
 import com.petrolpark.team.packet.BindTeamItemPacket;
 
@@ -34,6 +36,9 @@ public class PetrolparkMessages {
 
         addC2SPacket(BindTeamBlockPacket.class, BindTeamBlockPacket::new);
         addC2SPacket(BindTeamItemPacket.class, BindTeamItemPacket::new);
+
+        addS2CPacket(MEIShaderRemovePacket.class, MEIShaderRemovePacket::new);
+        addS2CPacket(SyncInitialDurationPacket.class, SyncInitialDurationPacket::new);
     };
 
     public static <T extends S2CPacket> void addS2CPacket(Class<T> clazz, Function<FriendlyByteBuf, T> decoder) {

--- a/src/main/java/com/petrolpark/shadereffects/IShaderEffect.java
+++ b/src/main/java/com/petrolpark/shadereffects/IShaderEffect.java
@@ -1,0 +1,18 @@
+package com.petrolpark.shadereffects;
+
+import com.petrolpark.network.PetrolparkMessages;
+import com.petrolpark.shadereffects.packet.MEIShaderRemovePacket;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.entity.LivingEntity;
+
+public interface IShaderEffect {
+    ResourceLocation getShader();
+
+    default void cleanupShader(LivingEntity pLivingEntity, MobEffect effect) {
+        if (pLivingEntity instanceof ServerPlayer ) {
+            PetrolparkMessages.sendToClient(new MEIShaderRemovePacket(effect), (( ServerPlayer ) pLivingEntity));
+        }
+    }
+}

--- a/src/main/java/com/petrolpark/shadereffects/ShaderEffectReloadHandler.java
+++ b/src/main/java/com/petrolpark/shadereffects/ShaderEffectReloadHandler.java
@@ -1,0 +1,53 @@
+package com.petrolpark.shadereffects;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.PostChain;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.world.effect.MobEffect;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class ShaderEffectReloadHandler {
+
+    private static final Map<ResourceLocation, PostChain> shaderCache = new HashMap<>();
+    public static final Set<IShaderEffect> forbiddenEffects = new HashSet<>();
+
+    public static void createShader(ResourceLocation location, IShaderEffect shaderEffect, Minecraft minecraft, ResourceManager manager) {
+        if (shaderCache.containsKey(location)) {
+            System.err.println("[Petrolpark] Cannot load shader location two times; Putting " + shaderEffect.getClass().getName() + " in forbidden effects");
+            forbiddenEffects.add(shaderEffect);
+            return;
+        }
+
+        try {
+            PostChain chain = new PostChain(minecraft.textureManager, manager, minecraft.getMainRenderTarget(), location);
+            chain.resize(minecraft.getWindow().getWidth(), minecraft.getWindow().getHeight());
+            shaderCache.put(location, chain);
+        } catch ( IOException exception ) {
+            System.err.println("[Petrolpark] Failed to preload shader: " + location);
+            exception.printStackTrace();
+        }
+    }
+
+    public static PostChain getShader(ResourceLocation location) {
+        return shaderCache.get(location);
+    }
+
+    public static boolean hasShader(ResourceLocation location) {
+        return shaderCache.containsKey(location);
+    }
+
+    public static void clearCache() {
+        shaderCache.values().forEach(PostChain::close);
+        shaderCache.clear();
+    }
+
+    public static boolean hasForbiddenEffect(MobEffect effect) {
+        return forbiddenEffects.contains((( IShaderEffect ) effect));
+    }
+}

--- a/src/main/java/com/petrolpark/shadereffects/ShaderEffectReloadHandler.java
+++ b/src/main/java/com/petrolpark/shadereffects/ShaderEffectReloadHandler.java
@@ -4,50 +4,38 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.PostChain;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.world.effect.MobEffect;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 public class ShaderEffectReloadHandler {
 
-    private static final Map<ResourceLocation, PostChain> shaderCache = new HashMap<>();
-    public static final Set<IShaderEffect> forbiddenEffects = new HashSet<>();
+    private static final Map<IShaderEffect, PostChain> shaderCache = new HashMap<>();
 
-    public static void createShader(ResourceLocation location, IShaderEffect shaderEffect, Minecraft minecraft, ResourceManager manager) {
-        if (shaderCache.containsKey(location)) {
-            System.err.println("[Petrolpark] Cannot load shader location two times; Putting " + shaderEffect.getClass().getName() + " in forbidden effects");
-            forbiddenEffects.add(shaderEffect);
-            return;
-        }
+    public static void createShader(IShaderEffect shaderEffect, Minecraft minecraft, ResourceManager manager) {
+        ResourceLocation location = shaderEffect.getShader();
 
         try {
             PostChain chain = new PostChain(minecraft.textureManager, manager, minecraft.getMainRenderTarget(), location);
             chain.resize(minecraft.getWindow().getWidth(), minecraft.getWindow().getHeight());
-            shaderCache.put(location, chain);
+            shaderCache.put(shaderEffect, chain);
         } catch ( IOException exception ) {
             System.err.println("[Petrolpark] Failed to preload shader: " + location);
             exception.printStackTrace();
         }
     }
 
-    public static PostChain getShader(ResourceLocation location) {
-        return shaderCache.get(location);
+    public static PostChain getShader(IShaderEffect shaderEffect) {
+        return shaderCache.get(shaderEffect);
     }
 
-    public static boolean hasShader(ResourceLocation location) {
-        return shaderCache.containsKey(location);
+    public static boolean hasShader(IShaderEffect shaderEffect) {
+        return shaderCache.containsKey(shaderEffect);
     }
 
     public static void clearCache() {
         shaderCache.values().forEach(PostChain::close);
         shaderCache.clear();
-    }
-
-    public static boolean hasForbiddenEffect(MobEffect effect) {
-        return forbiddenEffects.contains((( IShaderEffect ) effect));
     }
 }

--- a/src/main/java/com/petrolpark/shadereffects/packet/MEIShaderRemovePacket.java
+++ b/src/main/java/com/petrolpark/shadereffects/packet/MEIShaderRemovePacket.java
@@ -34,16 +34,16 @@ public class MEIShaderRemovePacket extends S2CPacket {
     public boolean handle(Supplier<NetworkEvent.Context> supplier) {
         supplier.get().enqueueWork(() -> {
             LocalPlayer player = Minecraft.getInstance().player;
+            if ( player == null ) return;
+
+            MobEffect effect = ForgeRegistries.MOB_EFFECTS.getValue(mobEffect);
+            if ( effect == null ) return;
+
+            MobEffectInstance instance = player.getEffect(effect);
+            if ( instance == null ) return;
+
             IGameRendererMixin gameRenderer = (( IGameRendererMixin ) Minecraft.getInstance().gameRenderer);
-            if ( player != null ) {
-                MobEffect effect = ForgeRegistries.MOB_EFFECTS.getValue(mobEffect);
-                if ( effect != null ) {
-                    MobEffectInstance instance = player.getEffect(effect);
-                    if ( instance != null ) {
-                        gameRenderer.removeMobEffectInstanceShader((( IMobEffectInstanceMixin ) instance));
-                    }
-                }
-            }
+            gameRenderer.removeMobEffectInstanceShader((( IMobEffectInstanceMixin ) instance));
         });
         return true;
     }

--- a/src/main/java/com/petrolpark/shadereffects/packet/MEIShaderRemovePacket.java
+++ b/src/main/java/com/petrolpark/shadereffects/packet/MEIShaderRemovePacket.java
@@ -1,0 +1,50 @@
+package com.petrolpark.shadereffects.packet;
+
+import com.petrolpark.network.packet.S2CPacket;
+import com.petrolpark.util.IGameRendererMixin;
+import com.petrolpark.util.IMobEffectInstanceMixin;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraftforge.network.NetworkEvent;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.function.Supplier;
+
+public class MEIShaderRemovePacket extends S2CPacket {
+    ResourceLocation mobEffect;
+
+    public MEIShaderRemovePacket(MobEffect mobEffect) {
+        this.mobEffect = ForgeRegistries.MOB_EFFECTS.getKey(mobEffect);
+    }
+
+    public MEIShaderRemovePacket(FriendlyByteBuf buffer) {
+        this.mobEffect = buffer.readResourceLocation();
+    }
+
+    @Override
+    public void toBytes(FriendlyByteBuf buffer) {
+        buffer.writeResourceLocation(this.mobEffect);
+    }
+
+    @Override
+    public boolean handle(Supplier<NetworkEvent.Context> supplier) {
+        supplier.get().enqueueWork(() -> {
+            LocalPlayer player = Minecraft.getInstance().player;
+            IGameRendererMixin gameRenderer = (( IGameRendererMixin ) Minecraft.getInstance().gameRenderer);
+            if ( player != null ) {
+                MobEffect effect = ForgeRegistries.MOB_EFFECTS.getValue(mobEffect);
+                if ( effect != null ) {
+                    MobEffectInstance instance = player.getEffect(effect);
+                    if ( instance != null ) {
+                        gameRenderer.removeMobEffectInstanceShader((( IMobEffectInstanceMixin ) instance));
+                    }
+                }
+            }
+        });
+        return true;
+    }
+}

--- a/src/main/java/com/petrolpark/shadereffects/packet/SyncInitialDurationPacket.java
+++ b/src/main/java/com/petrolpark/shadereffects/packet/SyncInitialDurationPacket.java
@@ -37,15 +37,15 @@ public class SyncInitialDurationPacket extends S2CPacket {
     public boolean handle(Supplier<NetworkEvent.Context> supplier) {
         supplier.get().enqueueWork(() -> {
             LocalPlayer player = Minecraft.getInstance().player;
-            if (player != null) {
-                MobEffect effect = ForgeRegistries.MOB_EFFECTS.getValue(mobEffectRL);
-                if (effect != null) {
-                    MobEffectInstance instance = player.getEffect(effect);
-                    if (instance != null) {
-                        (( IMobEffectInstanceMixin ) instance).setInitialDuration(initialDuration);
-                    }
-                }
-            }
+            if (player == null) return;
+
+            MobEffect effect = ForgeRegistries.MOB_EFFECTS.getValue(mobEffectRL);
+            if (effect == null) return;
+
+            MobEffectInstance instance = player.getEffect(effect);
+            if (instance == null) return;
+
+            (( IMobEffectInstanceMixin ) instance).setInitialDuration(initialDuration);
         });
         return true;
     }

--- a/src/main/java/com/petrolpark/shadereffects/packet/SyncInitialDurationPacket.java
+++ b/src/main/java/com/petrolpark/shadereffects/packet/SyncInitialDurationPacket.java
@@ -1,0 +1,52 @@
+package com.petrolpark.shadereffects.packet;
+
+import com.petrolpark.network.packet.S2CPacket;
+import com.petrolpark.util.IMobEffectInstanceMixin;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraftforge.network.NetworkEvent;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.function.Supplier;
+
+public class SyncInitialDurationPacket extends S2CPacket {
+    int initialDuration;
+    ResourceLocation mobEffectRL;
+
+    public SyncInitialDurationPacket(int initialDuration, MobEffect mobEffect) {
+        this.initialDuration = initialDuration;
+        this.mobEffectRL = ForgeRegistries.MOB_EFFECTS.getKey(mobEffect);
+    }
+
+    public SyncInitialDurationPacket(FriendlyByteBuf buffer) {
+        this.initialDuration = buffer.readInt();
+        this.mobEffectRL = buffer.readResourceLocation();
+    }
+
+    @Override
+    public void toBytes(FriendlyByteBuf buffer) {
+        buffer.writeInt(initialDuration);
+        buffer.writeResourceLocation(mobEffectRL);
+    }
+
+    @Override
+    public boolean handle(Supplier<NetworkEvent.Context> supplier) {
+        supplier.get().enqueueWork(() -> {
+            LocalPlayer player = Minecraft.getInstance().player;
+            if (player != null) {
+                MobEffect effect = ForgeRegistries.MOB_EFFECTS.getValue(mobEffectRL);
+                if (effect != null) {
+                    MobEffectInstance instance = player.getEffect(effect);
+                    if (instance != null) {
+                        (( IMobEffectInstanceMixin ) instance).setInitialDuration(initialDuration);
+                    }
+                }
+            }
+        });
+        return true;
+    }
+}

--- a/src/main/java/com/petrolpark/util/IGameRendererMixin.java
+++ b/src/main/java/com/petrolpark/util/IGameRendererMixin.java
@@ -1,0 +1,10 @@
+package com.petrolpark.util;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.effect.MobEffectInstance;
+
+public interface IGameRendererMixin {
+    void addMobEffectInstanceShader(ResourceLocation location, MobEffectInstance mobEffect);
+    void removeMobEffectInstanceShader(IMobEffectInstanceMixin effect);
+    void cleanShaderEffects();
+}

--- a/src/main/java/com/petrolpark/util/IMobEffectInstanceMixin.java
+++ b/src/main/java/com/petrolpark/util/IMobEffectInstanceMixin.java
@@ -1,0 +1,6 @@
+package com.petrolpark.util;
+
+public interface IMobEffectInstanceMixin {
+    void setInitialDuration(int duration);
+    void updateUniforms();
+}

--- a/src/main/resources/assets/minecraft/shaders/program/add.fsh
+++ b/src/main/resources/assets/minecraft/shaders/program/add.fsh
@@ -1,0 +1,13 @@
+#version 150
+
+uniform sampler2D DiffuseSampler;
+uniform sampler2D ToAdd;
+
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 diffuseTex = texture(DiffuseSampler, texCoord);
+    fragColor = diffuseTex + vec4(texture(ToAdd, texCoord).rgb, 0.0);
+}

--- a/src/main/resources/assets/minecraft/shaders/program/add.json
+++ b/src/main/resources/assets/minecraft/shaders/program/add.json
@@ -1,0 +1,18 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "srcalpha",
+    "dstrgb": "1-srcalpha"
+  },
+  "vertex": "blit",
+  "fragment": "add",
+  "attributes": [ "Position" ],
+  "samplers": [
+    { "name": "DiffuseSampler" },
+    { "name": "ToAdd"}
+  ],
+  "uniforms": [
+    { "name": "ProjMat",       "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+    { "name": "OutSize",       "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] }
+  ]
+}

--- a/src/main/resources/assets/minecraft/shaders/program/bezier_mix.fsh
+++ b/src/main/resources/assets/minecraft/shaders/program/bezier_mix.fsh
@@ -1,0 +1,50 @@
+#version 150
+
+uniform sampler2D DiffuseSampler;
+uniform sampler2D ToMix;
+
+uniform mat4x4 Points; //16 [ 0.0, 0.0, 0.0, 1.0, 0.1, 1.0, 0.5, 1.0, 0.5, 1.0, 0.9, 1.0, 1.0, 1.0, 1.0, 0.0 ]
+
+uniform float EffectFactor;
+
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+vec2 bezier(vec2 p1, vec2 p2, vec2 p3, vec2 p4, float dt) {
+    vec2 a1 = mix(p1, p2, dt);
+    vec2 a2 = mix(p2, p3, dt);
+    vec2 a3 = mix(p3, p4, dt);
+
+    vec2 b1 = mix(a1, a2, dt);
+    vec2 b2 = mix(a2, a3, dt);
+
+    return mix(b1, b2, dt);
+}
+
+void main() {
+    vec4 diffuseTex = texture(DiffuseSampler, texCoord);
+    vec4 toMixTex = texture(ToMix, texCoord);
+
+    vec2 point;
+
+    if (EffectFactor <= 0.5) {
+        point = bezier(
+            vec2(Points[0][0], Points[0][1]),
+            vec2(Points[0][2], Points[0][3]),
+            vec2(Points[1][0], Points[1][1]),
+            vec2(Points[1][2], Points[1][3]),
+            EffectFactor * 2.0
+        );
+    } else {
+        point = bezier(
+            vec2(Points[2][0], Points[2][1]),
+            vec2(Points[2][2], Points[2][3]),
+            vec2(Points[3][0], Points[3][1]),
+            vec2(Points[3][2], Points[3][3]),
+            (EffectFactor - 0.5) * 2.0
+        );
+    }
+
+    fragColor = mix(diffuseTex, toMixTex, point.y);
+}

--- a/src/main/resources/assets/minecraft/shaders/program/bezier_mix.json
+++ b/src/main/resources/assets/minecraft/shaders/program/bezier_mix.json
@@ -1,0 +1,20 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "srcalpha",
+    "dstrgb": "1-srcalpha"
+  },
+  "vertex": "blit",
+  "fragment": "bezier_mix",
+  "attributes": [ "Position" ],
+  "samplers": [
+    { "name": "DiffuseSampler" },
+    { "name":  "ToMix" }
+  ],
+  "uniforms": [
+    { "name": "ProjMat",       "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+    { "name": "OutSize",       "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+    { "name": "EffectFactor",  "type": "float",     "count": 1,  "values": [ 1.0 ] },
+    { "name":  "Points",       "type": "matrix4x4", "count": 16, "values": [ 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.5, 1.0, 0.5, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0 ] }
+  ]
+}

--- a/src/main/resources/assets/minecraft/shaders/program/ef_mix.fsh
+++ b/src/main/resources/assets/minecraft/shaders/program/ef_mix.fsh
@@ -1,0 +1,17 @@
+#version 150
+
+#define pi 3.14
+
+uniform sampler2D DiffuseSampler;
+uniform sampler2D ToMix;
+
+uniform float EffectFactor;
+
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 diffuseTex = texture(DiffuseSampler, texCoord);
+    fragColor = vec4(mix(diffuseTex.rgb, texture(ToMix, texCoord).rgb, 1-(1-cos((EffectFactor)*2*pi))/2), diffuseTex.a);
+}

--- a/src/main/resources/assets/minecraft/shaders/program/ef_mix.json
+++ b/src/main/resources/assets/minecraft/shaders/program/ef_mix.json
@@ -1,0 +1,19 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "srcalpha",
+    "dstrgb": "1-srcalpha"
+  },
+  "vertex": "blit",
+  "fragment": "ef_mix",
+  "attributes": [ "Position" ],
+  "samplers": [
+    { "name": "DiffuseSampler" },
+    { "name": "ToMix"}
+  ],
+  "uniforms": [
+    { "name": "ProjMat",       "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+    { "name": "OutSize",       "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+    { "name": "EffectFactor",  "type": "float",     "count": 1,  "values":  [ 0.5 ] }
+  ]
+}

--- a/src/main/resources/assets/minecraft/shaders/program/factor_mix.fsh
+++ b/src/main/resources/assets/minecraft/shaders/program/factor_mix.fsh
@@ -1,0 +1,19 @@
+#version 150
+
+#define pi 3.14
+
+uniform sampler2D DiffuseSampler;
+uniform sampler2D ToMix;
+uniform sampler2D Factor;
+
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 diffuseTex = texture(DiffuseSampler, texCoord);
+    vec4 toMixTex = texture(ToMix, texCoord);
+    vec4 factorTex = texture(Factor, vec2(0.0));
+    float factor = factorTex.r;
+    fragColor = vec4(mix(diffuseTex.rgb, toMixTex.rgb, factor), diffuseTex.a);
+}

--- a/src/main/resources/assets/minecraft/shaders/program/factor_mix.json
+++ b/src/main/resources/assets/minecraft/shaders/program/factor_mix.json
@@ -1,0 +1,19 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "srcalpha",
+    "dstrgb": "1-srcalpha"
+  },
+  "vertex": "blit",
+  "fragment": "factor_mix",
+  "attributes": [ "Position" ],
+  "samplers": [
+    { "name": "DiffuseSampler" },
+    { "name": "ToMix" },
+    { "name":  "Factor" }
+  ],
+  "uniforms": [
+    { "name": "ProjMat",       "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+    { "name": "OutSize",       "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] }
+  ]
+}

--- a/src/main/resources/assets/minecraft/shaders/program/multiply.fsh
+++ b/src/main/resources/assets/minecraft/shaders/program/multiply.fsh
@@ -1,0 +1,13 @@
+#version 150
+
+uniform sampler2D DiffuseSampler;
+uniform sampler2D ToMultiply;
+
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 diffuseTex = texture(DiffuseSampler, texCoord);
+    fragColor = diffuseTex * vec4(texture(ToMultiply, texCoord).xyz, 1.0);
+}

--- a/src/main/resources/assets/minecraft/shaders/program/multiply.json
+++ b/src/main/resources/assets/minecraft/shaders/program/multiply.json
@@ -1,0 +1,18 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "srcalpha",
+    "dstrgb": "1-srcalpha"
+  },
+  "vertex": "blit",
+  "fragment": "multiply",
+  "attributes": [ "Position" ],
+  "samplers": [
+    { "name": "DiffuseSampler" },
+    { "name": "ToMultiply" }
+  ],
+  "uniforms": [
+    { "name": "ProjMat",       "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+    { "name": "OutSize",       "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] }
+  ]
+}

--- a/src/main/resources/assets/minecraft/shaders/program/rectify.fsh
+++ b/src/main/resources/assets/minecraft/shaders/program/rectify.fsh
@@ -1,0 +1,15 @@
+#version 150
+
+uniform sampler2D DiffuseSampler;
+uniform vec3 Color;
+
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 diffuseTex = texture(DiffuseSampler, texCoord);
+    float difference = dot(Color, diffuseTex.rgb);
+
+    fragColor = vec4(vec3(difference), 1.0);
+}

--- a/src/main/resources/assets/minecraft/shaders/program/rectify.json
+++ b/src/main/resources/assets/minecraft/shaders/program/rectify.json
@@ -1,0 +1,18 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "srcalpha",
+    "dstrgb": "1-srcalpha"
+  },
+  "vertex": "blit",
+  "fragment": "rectify",
+  "attributes": [ "Position" ],
+  "samplers": [
+    { "name": "DiffuseSampler" }
+  ],
+  "uniforms": [
+    { "name": "ProjMat",       "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+    { "name": "OutSize",       "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+    { "name": "Color",         "type": "float",     "count": 3,  "values": [ 1.0, 1.0, 1.0 ]}
+  ]
+}

--- a/src/main/resources/assets/minecraft/shaders/program/subtract.fsh
+++ b/src/main/resources/assets/minecraft/shaders/program/subtract.fsh
@@ -1,0 +1,13 @@
+#version 150
+
+uniform sampler2D DiffuseSampler;
+uniform sampler2D ToSubtract;
+
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+void main() {
+    vec4 diffuseTex = texture(DiffuseSampler, texCoord);
+    fragColor = diffuseTex - vec4(texture(ToSubtract, texCoord).rgb, 0.0);
+}

--- a/src/main/resources/assets/minecraft/shaders/program/subtract.json
+++ b/src/main/resources/assets/minecraft/shaders/program/subtract.json
@@ -1,0 +1,18 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "srcalpha",
+    "dstrgb": "1-srcalpha"
+  },
+  "vertex": "blit",
+  "fragment": "subtract",
+  "attributes": [ "Position" ],
+  "samplers": [
+    { "name": "DiffuseSampler" },
+    { "name": "ToSubtract"}
+  ],
+  "uniforms": [
+    { "name": "ProjMat",       "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+    { "name": "OutSize",       "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] }
+  ]
+}

--- a/src/main/resources/assets/minecraft/shaders/program/unify.fsh
+++ b/src/main/resources/assets/minecraft/shaders/program/unify.fsh
@@ -1,0 +1,11 @@
+#version 150
+
+uniform vec3 Color;
+
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+void main() {
+    fragColor = vec4(Color, 1.0);
+}

--- a/src/main/resources/assets/minecraft/shaders/program/unify.json
+++ b/src/main/resources/assets/minecraft/shaders/program/unify.json
@@ -1,0 +1,17 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "srcalpha",
+    "dstrgb": "1-srcalpha"
+  },
+  "vertex": "blit",
+  "fragment": "unify",
+  "attributes": [ "Position" ],
+  "samplers": [
+  ],
+  "uniforms": [
+    { "name": "ProjMat",       "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+    { "name": "OutSize",       "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+    { "name": "Color",         "type": "float",     "count": 3,  "values": [ 1.0, 1.0, 1.0 ]}
+  ]
+}

--- a/src/main/resources/assets/petrolpark/shaders/post/baby_blue_high.json
+++ b/src/main/resources/assets/petrolpark/shaders/post/baby_blue_high.json
@@ -1,0 +1,35 @@
+{
+  "targets": [
+    "swap",
+    "swap2"
+  ],
+  "passes": [
+    {
+      "name": "color_convolve",
+      "intarget": "minecraft:main",
+      "outtarget": "swap",
+      "uniforms": [
+        {"name":  "Saturation", "values":  [ 3.0 ]}
+      ]
+    },
+    {
+      "name": "color_convolve",
+      "intarget": "minecraft:main",
+      "outtarget": "swap2",
+      "uniforms": [
+        {"name":  "Saturation", "values":  [ 1.0 ]}
+      ]
+    },
+    {
+      "name": "bezier_mix",
+      "intarget": "swap2",
+      "outtarget": "minecraft:main",
+      "auxtargets": [
+        {
+          "name": "ToMix",
+          "id": "swap"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/assets/petrolpark/shaders/post/baby_blue_withdrawal.json
+++ b/src/main/resources/assets/petrolpark/shaders/post/baby_blue_withdrawal.json
@@ -1,0 +1,106 @@
+{
+  "targets": [
+    "swap",
+    "swap1",
+    "swap2",
+    "swap3",
+    "swap4"
+  ],
+  "passes": [
+    {
+      "name": "color_convolve",
+      "intarget": "swap3",
+      "outtarget": "swap",
+      "uniforms": [
+        {"name":  "Saturation", "values":  [0]}
+      ]
+    },
+
+    {
+      "name": "deconverge",
+      "intarget": "minecraft:main",
+      "outtarget": "swap1",
+      "uniforms": [
+        {
+          "name": "ConvergeX",
+          "values": [ -32.0,  0.0,  2.0 ]
+        },
+        {
+          "name": "ConvergeY",
+          "values": [  0.0, -32.0,  2.0 ]
+        }
+      ]
+    },
+    {
+      "name": "subtract",
+      "intarget": "swap1",
+      "outtarget": "swap2",
+      "auxtargets": [
+        {
+          "name": "ToSubtract",
+          "id": "minecraft:main"
+        }
+      ]
+    },
+    {
+      "name": "rectify",
+      "intarget": "swap2",
+      "outtarget": "swap1",
+      "uniforms": [
+        {"name":  "Color", "values":  [1.0, 0.0, 0.0]}
+      ]
+    },
+    {
+      "name": "unify",
+      "intarget": "swap1",
+      "outtarget": "swap2",
+      "uniforms": [
+        {
+          "name": "Color",
+          "values": [ 1.0, 0.0, 0.0 ]
+        }
+      ]
+    },
+    {
+      "name": "multiply",
+      "intarget": "swap1",
+      "outtarget": "swap4",
+      "auxtargets": [
+        {
+          "name": "ToMultiply",
+          "id": "swap2"
+        }
+      ]
+    },
+    {
+      "name": "add",
+      "intarget": "swap",
+      "outtarget": "swap2",
+      "auxtargets": [
+        {
+          "name": "ToAdd",
+          "id": "swap4"
+        }
+      ]
+    },
+    {
+      "name": "color_convolve",
+      "intarget": "minecraft:main",
+      "outtarget": "swap3",
+      "uniforms": [
+        {"name":  "Saturation", "values":  [ 1.0 ]}
+      ]
+    },
+    {
+      "name": "bezier_mix",
+      "intarget": "swap3",
+      "outtarget": "minecraft:main",
+      "auxtargets": [
+        {
+          "name": "ToMix",
+          "id": "swap2"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/assets/petrolpark/shaders/post/lead_poisoning.json
+++ b/src/main/resources/assets/petrolpark/shaders/post/lead_poisoning.json
@@ -1,0 +1,74 @@
+{
+  "targets": [
+    "swap",
+    "swap1",
+    "swap2",
+    "swap3"
+  ],
+  "passes": [
+    {
+      "name": "color_convolve",
+      "intarget": "minecraft:main",
+      "outtarget": "swap",
+      "uniforms": [
+        {"name":  "Saturation", "values":  [0]}
+      ]
+    },
+    {
+      "name": "deconverge",
+      "intarget": "minecraft:main",
+      "outtarget": "swap1",
+      "uniforms": [
+        {
+          "name": "ConvergeX",
+          "values": [ -32.0,  0.0,  2.0 ]
+        },
+        {
+          "name": "ConvergeY",
+          "values": [  0.0, -32.0,  2.0 ]
+        }
+      ]
+    },
+    {
+      "name": "subtract",
+      "intarget": "swap1",
+      "outtarget": "swap2",
+      "auxtargets": [
+        {
+          "name": "ToSubtract",
+          "id": "minecraft:main"
+        }
+      ]
+    },
+    {
+      "name": "add",
+      "intarget": "swap2",
+      "outtarget": "swap1",
+      "auxtargets": [
+        {
+          "name": "ToAdd",
+          "id": "swap"
+        }
+      ]
+    },
+    {
+      "name": "color_convolve",
+      "intarget": "minecraft:main",
+      "outtarget": "swap3",
+      "uniforms": [
+        {"name":  "Saturation", "values":  [ 1.0 ]}
+      ]
+    },
+    {
+      "name": "bezier_mix",
+      "intarget": "swap3",
+      "outtarget": "minecraft:main",
+      "auxtargets": [
+        {
+          "name": "ToMix",
+          "id": "swap1"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/petrolpark.mixins.json
+++ b/src/main/resources/petrolpark.mixins.json
@@ -32,6 +32,8 @@
         "FluidTankMixin",
         "ItemStackMixin",
         "LivingEntityMixin",
+        "MobEffectMixin",
+        "MobEffectInstanceMixin",
         "ServerAdvancementManagerMixin",
         "ShapedRecipeMixin",
         "ShapelessRecipeMixin",
@@ -52,7 +54,9 @@
         "compat.create.client.GoggleOverlayRendererMixin",
         "compat.create.client.PonderUIMixin",
         "compat.jei.client.JustEnoughItemsClientMixin",
-        "client.CreativeModeInventoryScreenMixin"
+        "client.CreativeModeInventoryScreenMixin",
+        "client.GameRendererMixin",
+        "client.PostPassMixin"
     ],
     "injectors": {
         "defaultRequire": 1


### PR DESCRIPTION
Here is Destroy's PR edited for the library with some improvments...

A shadered MobEffect can be declared by implementing the `IShaderEffect` interface and by implementing the `getShader` method and returning a `ResourceLocation`. 
For example: `return Petrolpark.asResource("shaders/post/baby_blue_withdrawal.json");`

Example shaders meant for Destroy's effects are in `assets/petrolpark/shaders/post`

Might need some optimisations...

I didn't know where to put some files so left them in the `utils` directory