### PR TITLE
[1.21.1] Utilize NewRegistryEvent for registering registries; fix cyclical method call in `BatternPattern#getGenerator`

### DIFF
--- a/src/main/java/com/petrolpark/PetrolparkRegistries.java
+++ b/src/main/java/com/petrolpark/PetrolparkRegistries.java
@@ -1,6 +1,8 @@
 package com.petrolpark;
 
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 import org.jetbrains.annotations.ApiStatus;
@@ -28,14 +30,12 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.RegistrationInfo;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
-import net.minecraft.core.WritableRegistry;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.registries.NewRegistryEvent;
 import net.neoforged.neoforge.registries.RegistryBuilder;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 
@@ -88,6 +88,8 @@ public class PetrolparkRegistries {
         return object -> provider.lookupOrThrow(registryKey).listElements().filter(h -> h.value() == object).findAny();
     };
 
+    private static final Set<Registry<?>> registries = new HashSet<>();
+
     // Core
     public static final Registry<DecayProductType> DECAY_PRODUCT_TYPES = simple(Keys.DECAY_PRODUCT_TYPE);
     public static final Registry<ITeam.ProviderType> TEAM_PROVIDER_TYPES = simple(Keys.TEAM_PROVIDER_TYPE);
@@ -118,22 +120,23 @@ public class PetrolparkRegistries {
     };
 
     @ApiStatus.Internal
-    @SuppressWarnings({"deprecation", "unchecked", "rawtypes"})
+    @SuppressWarnings("deprecation")
 	public static <T> Registry<T> register(ResourceKey<Registry<T>> key, boolean hasIntrusiveHolders) {
 		RegistryBuilder<T> builder = new RegistryBuilder<>(key).sync(true);
 
 		if (hasIntrusiveHolders) builder.withIntrusiveHolders();
 
 		Registry<T> registry = builder.create();
-		((WritableRegistry) BuiltInRegistries.REGISTRY).register(key, registry, RegistrationInfo.BUILT_IN);
+        registries.add(registry);
 		return registry;
 	};
 
-	@ApiStatus.Internal
-	public static void init() {
-		// make sure the class is loaded.
-		// this method is called at the tail of BuiltInRegistries, injected by BuiltInRegistriesMixin.
-	};
+    @ApiStatus.Internal
+    public static void init(NewRegistryEvent event) {
+        for (Registry<?> registry : registries) {
+            event.register(registry);
+        }
+    }
     
     public static class Keys {
         // Core

--- a/src/main/java/com/petrolpark/core/recipe/bogglepattern/BogglePattern.java
+++ b/src/main/java/com/petrolpark/core/recipe/bogglepattern/BogglePattern.java
@@ -32,7 +32,7 @@ public class BogglePattern {
     };
     
     public IBogglePatternGenerator getGenerator() {
-        return getGenerator();
+        return this.generator;
     };
 
     public int getPattern(Level level) {

--- a/src/main/java/com/petrolpark/event/ModEvents.java
+++ b/src/main/java/com/petrolpark/event/ModEvents.java
@@ -10,6 +10,7 @@ import com.petrolpark.core.shop.offer.ShopOfferGenerator;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.registries.DataPackRegistryEvent;
+import net.neoforged.neoforge.registries.NewRegistryEvent;
 
 @EventBusSubscriber(modid = Petrolpark.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
 public class ModEvents {
@@ -21,4 +22,9 @@ public class ModEvents {
         event.dataPackRegistry(PetrolparkRegistries.Keys.SHOP_OFFER_GENERATOR, ShopOfferGenerator.DIRECT_CODEC, ShopOfferGenerator.DIRECT_CODEC);
         event.dataPackRegistry(PetrolparkRegistries.Keys.BOGGLE_PATTERN, BogglePattern.DIRECT_CODEC, BogglePattern.DIRECT_NETWORK_CODEC);
     };
+
+    @SubscribeEvent
+    public static final void onNewRegistry(NewRegistryEvent event) {
+        PetrolparkRegistries.init(event);
+    }
 };

--- a/src/main/java/com/petrolpark/mixin/BuiltInRegistriesMixin.java
+++ b/src/main/java/com/petrolpark/mixin/BuiltInRegistriesMixin.java
@@ -16,10 +16,6 @@ import net.minecraft.core.registries.BuiltInRegistries;
 @Mixin(BuiltInRegistries.class)
 public class BuiltInRegistriesMixin {
 
-	static {
-		PetrolparkRegistries.init();
-	};
-
 	@WrapOperation(
         method = "validate",
         at = @At(


### PR DESCRIPTION
`NewRegistryEvent` is very much preferred to using mixins to register registries. This accounts for the latest crash reports in #48 and fixes #52.

The cyclical call in `BatternPattern#getGenerator` was just something I noticed while testing to make sure the mod worked.