### PR TITLE
Update ItemStackMixin#inIsSameItemSameTags to not unspool the CompoundTag

### DIFF
--- a/src/main/java/com/petrolpark/mixin/ItemStackMixin.java
+++ b/src/main/java/com/petrolpark/mixin/ItemStackMixin.java
@@ -6,6 +6,9 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+
 import com.petrolpark.contamination.IContamination;
 import com.petrolpark.contamination.IItemStackDuck;
 import com.petrolpark.contamination.ItemContamination;
@@ -35,8 +38,9 @@ public class ItemStackMixin implements IItemStackDuck {
         at = @At("HEAD"),
         cancellable = true
     )
-    private static void inIsSameItemSameTags(ItemStack stack, ItemStack otherStack, CallbackInfoReturnable<Boolean> cir) {
-        cir.setReturnValue(ItemHelper.equalIgnoringTags(stack, otherStack));
+    private static void inIsSameItemSameTags(ItemStack stack, ItemStack otherStack, CallbackInfoReturnable<Boolean> cir, @Local(argsOnly=true, ordinal=0) LocalRef<ItemStack> arg1, @Local(argsOnly=true, ordinal=1) LocalRef<ItemStack> arg2) {
+        arg1.set(IDecayingItem.checkDecay(stack));
+        arg2.set(IDecayingItem.checkDecay(otherStack));
     }
 
     @Override


### PR DESCRIPTION
I'm assuming you use `ItemHelper#equalIgnoringTags` here to unwrap decayed items since there's no tags specified to ignore, but it also completely _deep-searches_ the NBT, which ends up using almost 15% of the total time per tick on my server.

This changes the mixin to just make MC's native equals check use the unwrapped decayed items, without using the really expensive deep-equals method.