### PR TITLE
Fix incompatibilities (Caused by ExtendedInventory)

### DIFF
--- a/src/main/java/com/petrolpark/core/extendedinventory/ExtendedInventory.java
+++ b/src/main/java/com/petrolpark/core/extendedinventory/ExtendedInventory.java
@@ -134,10 +134,13 @@ public class ExtendedInventory extends Inventory {
      * @see ExtendedInventory#refreshPlayerInventoryMenuServer(Player) Refresh the Inventory Menu with the Slots in unknown positions (possible on the server side)
      */
     public static void refreshPlayerInventoryMenu(Player player, int columns, int invX, int invY, int leftHotbarSlots, int leftHotbarX, int leftHotbarY, int rightHotbarX, int rightHotbarY) {
-        player.inventoryMenu = new InventoryMenu(player.getInventory(), !player.level().isClientSide(), player); // Usually this field would be final; don't tell anybody I did this
+        InventoryMenu oldMenu = player.inventoryMenu;
+        InventoryMenu newMenu = new InventoryMenu(player.getInventory(), !player.level().isClientSide(), player); // Usually this field would be final; don't tell anybody I did this
+        player.inventoryMenu = newMenu;
         get(player).ifPresent(inv -> inv.addExtraInventorySlotsToMenu(player.inventoryMenu, columns, invX, invY, leftHotbarSlots, leftHotbarX, leftHotbarY, rightHotbarX, rightHotbarY));
         player.containerMenu = player.inventoryMenu;
         if (player instanceof ServerPlayer sp && sp.containerSynchronizer != null && sp.containerListener != null) sp.initInventoryMenu();
+        newMenu.containerListeners.addAll(oldMenu.containerListeners);
     };
 
     /**

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -38,6 +38,7 @@ private-f net.minecraft.world.entity.player.Player inventory
 public-f net.minecraft.world.entity.player.Player inventoryMenu
 public net.minecraft.server.level.ServerPlayer containerSynchronizer
 public net.minecraft.server.level.ServerPlayer containerListener
+public net.minecraft.world.inventory.AbstractContainerMenu containerListeners
 public net.minecraft.world.inventory.AbstractContainerMenu lastSlots
 public net.minecraft.world.inventory.AbstractContainerMenu remoteSlots
 public net.minecraft.world.inventory.AbstractContainerMenu addSlot(Lnet/minecraft/world/inventory/Slot;)Lnet/minecraft/world/inventory/Slot;


### PR DESCRIPTION
Fixes incompatibilities with other mods such as FTB Quests.
These incompatibilities are caused by container listeners not being moved over to the new inventory menu.

This pull request makes the same changes as [https://github.com/Petrolpark-Mods/Destroy/pull/764](https://github.com/Petrolpark-Mods/Destroy/pull/764)