### PR TITLE
fix(crash): IndexOutOfBoundsException caused by Create: Connected's KineticBridgeDestination

### DIFF
--- a/src/main/java/com/petrolpark/mixin/compat/create/RotationPropagatorMixin.java
+++ b/src/main/java/com/petrolpark/mixin/compat/create/RotationPropagatorMixin.java
@@ -108,7 +108,6 @@ public class RotationPropagatorMixin {
     )
     private static void petrolpark$getCurrentBEIndex(KineticBlockEntity updateTE, CallbackInfo ci, @Share("index") LocalIntRef indexRef, @Share("indexFrontier") LocalRef<List<Integer>> indexFrontierRef) {
         indexRef.set(indexFrontierRef.get().remove(0));
-        Petrolpark.LOGGER.info("checking index " + indexRef.get());
     };
 
     /**
@@ -122,7 +121,11 @@ public class RotationPropagatorMixin {
         )
     )
     private static BlockEntity petrolpark$getCorrectCompositePart(BlockEntity original, @Share("index") LocalIntRef indexRef) {
-        return original instanceof CompositeKineticBlockEntity composite ? composite.getParts().get(indexRef.get()) : original;
+        // Was: no guard on index, -1 would cause IndexOutOfBounds or wrong part
+        if (!(original instanceof CompositeKineticBlockEntity composite)) return original;
+        int index = indexRef.get();
+        if (index < 0 || index >= composite.getParts().size()) return original;
+        return composite.getParts().get(index);
     };
 
     /**
@@ -169,7 +172,7 @@ public class RotationPropagatorMixin {
         )
     )
     private static void petrolpark$addNeighbourIndexToFrontier(KineticBlockEntity updateTE, CallbackInfo ci, @Share("indexFrontier") LocalRef<List<Integer>> indexFrontierRef, @Local(ordinal = 2) KineticBlockEntity neighbourBE) {
-        if (neighbourBE instanceof CompositeKineticBlockEntityPart part) indexFrontierRef.get().add(part.getIndex());
+        indexFrontierRef.get().add(neighbourBE instanceof CompositeKineticBlockEntityPart part ? part.getIndex() : -1);
     };
 
     @ModifyExpressionValue(

--- a/src/main/java/com/petrolpark/mixin/compat/create/RotationPropagatorMixin.java
+++ b/src/main/java/com/petrolpark/mixin/compat/create/RotationPropagatorMixin.java
@@ -121,7 +121,6 @@ public class RotationPropagatorMixin {
         )
     )
     private static BlockEntity petrolpark$getCorrectCompositePart(BlockEntity original, @Share("index") LocalIntRef indexRef) {
-        // Was: no guard on index, -1 would cause IndexOutOfBounds or wrong part
         if (!(original instanceof CompositeKineticBlockEntity composite)) return original;
         int index = indexRef.get();
         if (index < 0 || index >= composite.getParts().size()) return original;


### PR DESCRIPTION
When Create: Connected added non-composite neighbours to Create's BFS frontier, petrolpark's parallel index list would fall out of sync and crash on an empty remove(0). Fixed by always adding -1 for non-composite neighbours, and guarding against that -1 when looking up composite parts.

Also removed left in logger that was spamming the logs on network changes.