### PR TITLE
🐛 Fix JEI 19.32 mixin targets

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ catnip_version = 0.8.54
 sable_companion_version = 1.6.0
 pquality_version = 0.3.1
 
-jei_version = 19.27.0.335
+jei_version = 19.32.0.358
 curios_version = 9.2.2
 jade_id = 6011258
 chipped_version = 4.0.2

--- a/src/main/java/petrolpark/mc/library/mixin/compat/jei/client/ModIdHelperMixin.java
+++ b/src/main/java/petrolpark/mc/library/mixin/compat/jei/client/ModIdHelperMixin.java
@@ -1,6 +1,7 @@
 package petrolpark.mc.library.mixin.compat.jei.client;
 
 import java.util.Arrays;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -17,11 +18,11 @@ import petrolpark.mc.library.shared.SharedFeatureFlag;
 import petrolpark.mc.library.util.Lang;
 
 import mezz.jei.api.helpers.IModIdHelper;
-import mezz.jei.api.ingredients.IIngredientHelper;
+import mezz.jei.api.ingredients.ITypedIngredient;
 import mezz.jei.library.helpers.ModIdHelper;
 import net.minecraft.world.item.ItemStack;
 
-@Mixin(ModIdHelper.class)
+@Mixin(value = ModIdHelper.class, remap = false)
 public abstract class ModIdHelperMixin implements IModIdHelper {
 
     private static final String SHARED_FEATURE_ID_KEY = Petrolpark.MOD_ID + "shared";
@@ -31,16 +32,21 @@ public abstract class ModIdHelperMixin implements IModIdHelper {
         method = "Lmezz/jei/library/helpers/ModIdHelper;getModNameForTooltip(Lmezz/jei/api/ingredients/ITypedIngredient;)Ljava/util/Optional;",
         at = @At(
             value = "INVOKE",
-            target = "Lmezz/jei/api/ingredients/IIngredientHelper;getDisplayModId(Ljava/lang/Object;)Ljava/lang/String;"
-        )
+            target = "Ljava/util/function/Function;apply(Ljava/lang/Object;)Ljava/lang/Object;",
+            ordinal = 0
+        ),
+        require = 1
     )
-    @SuppressWarnings("rawtypes")
-    public String petrolpark$getSharedFeatureModIds(IIngredientHelper instance, Object ingredient, Operation<String> original) {
-        if (ingredient instanceof ItemStack stack && stack.getItem() instanceof ISharedFeature sharedFeature) {
+    private Object petrolpark$getSharedFeatureModIds(Function<?, ?> instance, Object argument, Operation<Object> original) {
+        Object jeiResult = original.call(instance, argument);
+        if (argument instanceof ITypedIngredient<?> typedIngredient
+            && typedIngredient.getIngredient() instanceof ItemStack stack
+            && stack.getItem() instanceof ISharedFeature sharedFeature
+        ) {
             SharedFeatureFlag featureFlag = sharedFeature.getSharedFeatureFlag();
             if (featureFlag.enabled()) return SHARED_FEATURE_ID_KEY + DELIMITER + featureFlag.streamUsers().map(Mods::getId).collect(Collectors.joining(DELIMITER));
         };
-        return original.call(instance, ingredient);
+        return jeiResult;
     };
     
     @WrapMethod(

--- a/src/main/java/petrolpark/mc/library/mixin/compat/jei/client/RecipeCategoryTabMixin.java
+++ b/src/main/java/petrolpark/mc/library/mixin/compat/jei/client/RecipeCategoryTabMixin.java
@@ -1,5 +1,8 @@
 package petrolpark.mc.library.mixin.compat.jei.client;
 
+import java.util.stream.Collectors;
+
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -9,28 +12,36 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import petrolpark.mc.library.Petrolpark;
 import petrolpark.mc.library.compat.Mods;
 import petrolpark.mc.library.shared.ISharedFeature;
-import petrolpark.mc.library.util.Lang;
 
 import mezz.jei.api.helpers.IModIdHelper;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import mezz.jei.gui.recipes.RecipeCategoryTab;
+import net.minecraft.network.chat.Component;
 
-@Mixin(RecipeCategoryTab.class)
+@Mixin(value = RecipeCategoryTab.class, remap = false)
 public abstract class RecipeCategoryTabMixin {
+
+    private static final String SHARED_FEATURE_ID_KEY = Petrolpark.MOD_ID + "shared";
+    private static final String DELIMITER = ",";
     
     @Shadow
+    @Final
     private IRecipeCategory<?> category;
 
     @WrapOperation(
         method = "Lmezz/jei/gui/recipes/RecipeCategoryTab;getTooltip()Lmezz/jei/common/gui/JeiTooltip;",
         at = @At(
             value = "INVOKE",
-            target = "Lmezz/jei/api/helpers/IModIdHelper;getFormattedModNameForModId(Ljava/lang/String;)Ljava/lang/String;"
-        )
+            target = "Lmezz/jei/api/helpers/IModIdHelper;getFormattedModNameComponentForModId(Ljava/lang/String;)Lnet/minecraft/network/chat/Component;",
+            ordinal = 0
+        ),
+        require = 1
     )
-    public String petrolpark$getSharedFeatureModIds(IModIdHelper instance, String modid, Operation<String> original) {
+    private Component petrolpark$getSharedFeatureModIds(IModIdHelper instance, String modid, Operation<Component> original) {
         if (Petrolpark.MOD_ID.equals(modid) && category instanceof ISharedFeature sharedCategory) {
-            return Lang.shortList(sharedCategory.getSharedFeatureFlag().streamUsers().map(Mods::getId).map(id -> original.call(instance, id)).toArray(String[]::new));
-        } else return original.call(instance, modid);
+            String sharedModIds = sharedCategory.getSharedFeatureFlag().streamUsers().map(Mods::getId).collect(Collectors.joining(DELIMITER));
+            if (!sharedModIds.isEmpty()) return original.call(instance, SHARED_FEATURE_ID_KEY + DELIMITER + sharedModIds);
+        };
+        return original.call(instance, modid);
     };
 };

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -45,7 +45,7 @@ file="META-INF/accesstransformer.cfg"
 [[dependencies.${mod_id}]]
     modId = "jei"
     type = "optional"
-    versionRange = "[19.25.0.321,19.28.0.0)"
+    versionRange = "[19.32.0.358,19.40.0.0)"
     reason = "This library modifies JEI using mixins, whose targets may change in newer updates"
     ordering = "AFTER"
     side = "CLIENT"


### PR DESCRIPTION
## Summary

Fixes Petrolpark's shared-feature item and recipe-category tooltips
with JEI 19.32.0.358 through 19.39.x.

Fixes #124

## Cause

JEI's mod-name formatting refactor was backported to Minecraft 1.21.1
as API 19.31.0 and first released for NeoForge in 19.32.0.358.

The refactor changed both invocation targets used by Petrolpark's
shared-feature tooltip mixins:

- `IIngredientHelper#getDisplayModId` was replaced by `Function#apply`
- `getFormattedModNameForModId` was replaced by
  `getFormattedModNameComponentForModId`

The existing `@WrapOperation` injection points therefore no longer
matched, resulting in a critical `0/1 succeeded` injection failure when
JEI initialized its inventory UI.

JEI change:
https://github.com/mezz/JustEnoughItems/commit/88ed79e341f4f8d712cc893847055198e3e06a62

## Changes

- Updates `ModIdHelperMixin` for JEI's new display-mod-ID function
- Updates `RecipeCategoryTabMixin` for the component-based formatter
- Preserves Petrolpark's existing `petrolparkshared,<mod ids>` marker
- Keeps `petrolpark$formatSharedFeatureModIds` in place
- Raises the supported JEI range to `[19.32.0.358,19.40.0.0)`

## Testing

- [x] `gradlew clean build`
- [x] Client launch with JEI 19.32.0.358
- [x] Client launch with JEI 19.39.0.370
- [x] Shared-feature item tooltip
- [x] Shared recipe-category tooltip
- [x] Normal item and category tooltips
- [x] Dedicated server launch